### PR TITLE
Add regression tests and document testing workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,23 @@ pip install -e .
 ```
 This will install the `check-hang`, `check-nan`, `get-healthy-nodes`, `check-mate-launcher`, and `check-mate-flush` command line tools into your environment.
 
+## Running the test suite
+
+The project ships with a comprehensive pytest suite that exercises both the numerical checkpoint
+optimizer and the command-line monitors. To run the tests locally:
+
+```bash
+python -m venv .venv
+source .venv/bin/activate
+pip install -e .[dev]
+pip install pytest
+pytest
+```
+
+If you prefer not to use the optional development extras, ensure that `pytest`, `numpy`, and
+`scipy` are installed in your active environment before invoking the test command. The suite also
+includes filesystem-based checks, so running it from a writable working directory is recommended.
+
 ## Python usage
 
 ```python

--- a/docs/index.md
+++ b/docs/index.md
@@ -25,3 +25,15 @@ print(cm.__version__)
 - `check-mate-flush` — run the original flush helper used in PBS-style workflows.
 
 Refer to the [project README](https://github.com/argonne-lcf/checkpoint_restart#readme) for detailed usage examples.
+
+## Testing and verification
+
+We maintain a pytest-driven regression suite that validates the optimal checkpoint calculations and
+the file-monitoring utilities. After installing the project (and optional `dev` extras), run:
+
+```bash
+pytest
+```
+
+The tests exercise filesystem interactions, process termination hooks, and numerical solvers, so a
+local Python environment with `numpy`, `scipy`, and `pytest` is required.

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,3 @@
+[pytest]
+testpaths = tests
+addopts = -ra

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,7 @@
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+SRC = ROOT / "src"
+if SRC.exists():
+    sys.path.insert(0, str(SRC))

--- a/tests/test_check_hang.py
+++ b/tests/test_check_hang.py
@@ -1,0 +1,36 @@
+import os
+import time
+
+from check_mate.check_hang import get_date, most_recent_mtime
+
+
+def test_get_date_formats_timestamp():
+    timestamp = 1_700_000_000  # fixed epoch for reproducibility
+    formatted = get_date(timestamp)
+    assert formatted == time.strftime("%Y-%m-%d %H:%M:%S", time.localtime(timestamp))
+
+
+def test_most_recent_mtime_returns_latest(tmp_path):
+    file_a = tmp_path / "a.out"
+    file_b = tmp_path / "b.out"
+    file_a.write_text("a")
+    file_b.write_text("b")
+
+    # Ensure b has a newer timestamp
+    os.utime(file_b, None)
+
+    result = most_recent_mtime([file_a, file_b])
+    assert result == file_b.stat().st_mtime
+
+
+def test_most_recent_mtime_ignores_missing(tmp_path):
+    missing = tmp_path / "missing.dat"
+    existing = tmp_path / "existing.dat"
+    existing.write_text("data")
+
+    result = most_recent_mtime([missing, existing])
+    assert result == existing.stat().st_mtime
+
+
+def test_most_recent_mtime_returns_none_when_empty():
+    assert most_recent_mtime([]) is None

--- a/tests/test_check_nan.py
+++ b/tests/test_check_nan.py
@@ -1,0 +1,122 @@
+import argparse
+import os
+import signal
+from types import SimpleNamespace
+
+import pytest
+
+from check_mate import check_nan
+
+
+def test_split_outputs_handles_mixed_delimiters():
+    specs = check_nan.split_outputs(" log1.txt:logs/*.out , result.log :: metrics.csv ")
+    assert specs == ["log1.txt", "logs/*.out", "result.log", "metrics.csv"]
+
+
+def test_is_glob_detects_special_characters():
+    assert check_nan.is_glob("*.log")
+    assert not check_nan.is_glob("logs/output.log")
+
+
+def test_list_files_returns_existing_files(tmp_path):
+    file_a = tmp_path / "a.log"
+    file_a.write_text("hello")
+    nested = tmp_path / "nested"
+    nested.mkdir()
+    file_b = nested / "b.log"
+    file_b.write_text("world!")
+
+    specs = [str(file_a), str(tmp_path / "*.log"), str(nested / "*.log")]
+    files = check_nan.list_files(specs, recursive=False)
+
+    assert files[str(file_a)] == len("hello")
+    assert files[str(file_b)] == len("world!")
+
+
+def test_scan_new_bytes_tracks_offsets(tmp_path):
+    target = tmp_path / "log.txt"
+    target.write_text("12345")
+
+    end, chunk = check_nan.scan_new_bytes(str(target), 0)
+    assert end == 5
+    assert chunk == "12345"
+
+    target.write_text("12345abcdef")
+    end, chunk = check_nan.scan_new_bytes(str(target), end)
+    assert end == len("12345abcdef")
+    assert chunk == "abcdef"
+
+
+def test_scan_new_bytes_missing_file_is_safe(tmp_path):
+    start, chunk = check_nan.scan_new_bytes(str(tmp_path / "missing.log"), 10)
+    assert start == 10
+    assert chunk == ""
+
+
+def test_contains_bad_tokens_detects_nan_and_inf():
+    assert check_nan.contains_bad_tokens("loss=nan", include_inf=False)
+    assert check_nan.contains_bad_tokens("loss=INF", include_inf=True)
+    assert not check_nan.contains_bad_tokens("all good", include_inf=True)
+
+
+@pytest.fixture()
+def fake_sleep(monkeypatch):
+    monkeypatch.setattr(check_nan.time, "sleep", lambda _: None)
+
+
+def test_try_kill_pid_and_command(monkeypatch, fake_sleep, capsys):
+    kills: list[tuple[int, int]] = []
+    commands: list[str] = []
+
+    def fake_kill(pid: int, sig: int) -> None:
+        if sig != 0:
+            kills.append((pid, sig))
+
+    def fake_run(cmd, shell, check):
+        assert shell and not check
+        commands.append(cmd)
+
+    monkeypatch.setattr(os, "kill", fake_kill)
+    monkeypatch.setattr(check_nan.subprocess, "run", fake_run)
+
+    args = argparse.Namespace(
+        dry_run=False,
+        pid=4242,
+        signal="TERM",
+        grace=1,
+        kill_command="echo kill",
+    )
+
+    check_nan.try_kill(args)
+
+    # After first invocation we expect TERM signal, escalation to SIGKILL, and the
+    # kill command execution.
+    assert (4242, getattr(signal, "SIGTERM")) in kills
+    assert (4242, signal.SIGKILL) in kills
+    assert commands == ["echo kill"]
+
+
+def test_try_kill_dry_run(capsys):
+    args = SimpleNamespace(
+        dry_run=True,
+        pid=0,
+        signal="TERM",
+        grace=0,
+        kill_command="",
+    )
+    check_nan.try_kill(args)
+    captured = capsys.readouterr()
+    assert "[DRY-RUN] Would terminate job" in captured.out
+
+
+def test_try_kill_warns_when_no_action(monkeypatch, capsys):
+    args = SimpleNamespace(
+        dry_run=False,
+        pid=0,
+        signal="TERM",
+        grace=0,
+        kill_command="",
+    )
+    check_nan.try_kill(args)
+    captured = capsys.readouterr()
+    assert "No kill action executed" in captured.out

--- a/tests/test_optimal_checkpointing.py
+++ b/tests/test_optimal_checkpointing.py
@@ -1,0 +1,96 @@
+import math
+import pytest
+
+from check_mate.optimal_checkpointing import compute_efficiency, optimal_checkpoint_cadence
+
+
+def solve_expected_cadence(
+    node_count: int,
+    node_memory: float,
+    *,
+    MTBAI: float = 0.67,
+    chkpt_bandwidth: float = 5000.0,
+    R_0: float | None = None,
+) -> float:
+    """Re-implement the scalar root solve using a pure-Python bisection check."""
+    if R_0 is None:
+        R_0 = 1 / (MTBAI * 10624)
+
+    tau_c = (node_memory / chkpt_bandwidth) / 3600
+    u_chk = tau_c * node_count**2
+    z_chk = R_0 * u_chk
+
+    def f(z_c: float) -> float:
+        return math.exp(-z_c - z_chk) - (1 - z_c)
+
+    lo, hi = 0.0, max(1.5 * z_chk, 1.0)
+    f_lo = f(lo)
+    f_hi = f(hi)
+    assert f_lo * f_hi <= 0, "Bracket must contain the root"
+
+    for _ in range(200):
+        mid = 0.5 * (lo + hi)
+        f_mid = f(mid)
+        if abs(f_mid) <= 1e-12 or hi - lo <= 1e-12:
+            z_c = mid
+            break
+        if f_mid * f_lo > 0:
+            lo, f_lo = mid, f_mid
+        else:
+            hi, f_hi = mid, f_mid
+    else:  # pragma: no cover - defensive guard
+        raise RuntimeError("Bisection did not converge")
+
+    u_c = z_c / R_0
+    return u_c / node_count
+
+
+def test_optimal_checkpoint_cadence_matches_reference_bandwidth_default():
+    cadence = optimal_checkpoint_cadence(node_count=64, node_memory=32)
+    expected = solve_expected_cadence(node_count=64, node_memory=32)
+    assert cadence == pytest.approx(expected, rel=1e-6)
+
+
+def test_optimal_checkpoint_cadence_respects_named_bandwidth():
+    cadence = optimal_checkpoint_cadence(
+        node_count=64,
+        node_memory=32,
+        chkpt_bandwidth="LUSTRE",
+    )
+    expected = solve_expected_cadence(
+        node_count=64,
+        node_memory=32,
+        chkpt_bandwidth=650.0,
+    )
+    assert cadence == pytest.approx(expected, rel=1e-6)
+
+
+@pytest.mark.parametrize(
+    "field,kwargs",
+    [
+        ("node_count", {"node_count": 0, "node_memory": 32}),
+        ("node_memory", {"node_count": 64, "node_memory": 0}),
+        ("chkpt_bandwidth", {"node_count": 64, "node_memory": 32, "chkpt_bandwidth": 0}),
+    ],
+)
+def test_optimal_checkpoint_cadence_rejects_non_positive_parameters(field, kwargs):
+    with pytest.raises(ValueError) as excinfo:
+        optimal_checkpoint_cadence(**kwargs)
+    assert field in str(excinfo.value)
+
+
+def test_optimal_checkpoint_cadence_invalid_bandwidth_label():
+    with pytest.raises(TypeError):
+        optimal_checkpoint_cadence(node_count=8, node_memory=8, chkpt_bandwidth="UNKNOWN")
+
+
+def test_compute_efficiency_matches_manual_result():
+    cadence = optimal_checkpoint_cadence(node_count=64, node_memory=32)
+    efficiency = compute_efficiency(node_count=64, node_memory=32)
+    expected_eff = math.exp(-(4.0 + 3.0) / cadence)
+    assert efficiency == pytest.approx(expected_eff, rel=1e-6)
+
+
+def test_compute_efficiency_warns_for_tiny_cadence():
+    with pytest.warns(UserWarning):
+        compute_efficiency(node_count=4096, node_memory=8)


### PR DESCRIPTION
## Summary
- add a pytest configuration and shared conftest to isolate the package sources during testing
- implement regression coverage for the checkpoint cadence math and the CLI monitoring helpers
- document the recommended pytest workflow in both the README and MkDocs site

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e7f0164ba8832aa4bec9e3d976197f

## Summary by Sourcery

Add a pytest-based regression test suite for numerical checkpointing and CLI monitoring utilities, configure pytest, and document the recommended testing workflow in README and MkDocs documentation.

Build:
- Added pytest.ini to configure test discovery paths and reporting options.

Documentation:
- Documented the pytest workflow including environment setup and dependencies in README and MkDocs documentation.

Tests:
- Added regression tests for check_nan covering output splitting, file scanning, token detection, and termination logic.
- Added regression tests for optimal_checkpoint_cadence and compute_efficiency validating numerical accuracy and error handling.
- Added regression tests for check_hang covering timestamp formatting and file modification tracking.
- Introduced a shared conftest to isolate the package source directory during tests.