### PR TITLE
Adopt uv build backend and rename CLIs

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,9 +1,10 @@
 repos:
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.4.4
+    rev: v0.5.4
     hooks:
-      - id: ruff
       - id: ruff-format
+      - id: ruff
+        args: ["--fix"]
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v4.5.0
     hooks:

--- a/README.md
+++ b/README.md
@@ -23,7 +23,38 @@ git clone https://github.com/argonne-lcf/checkpoint_restart
 cd checkpoint_restart
 pip install -e .
 ```
-This will install the `check-hang`, `check-nan`, `get-healthy-nodes`, `check-mate-launcher`, and `check-mate-flush` command line tools into your environment.
+This will install the `check-mate-hang`, `check-mate-nan`, `get-healthy-nodes`, `check-mate-launcher`, and `check-mate-flush` command line tools into your environment.
+
+## Running the test suite
+
+The project ships with a comprehensive pytest suite that exercises both the numerical checkpoint
+optimizer and the command-line monitors. To run the tests locally:
+
+```bash
+python -m venv .venv
+source .venv/bin/activate
+pip install -e .[dev]
+pytest
+```
+
+The optional `dev` extras include `pytest`, so no additional installation steps are required. If you
+prefer not to use those extras, ensure that `pytest`, `numpy`, and `scipy` are installed in your
+active environment before invoking the test command. The suite also includes filesystem-based
+checks, so running it from a writable working directory is recommended. For additional guidance,
+including troubleshooting tips, see the [Testing guide](docs/index.md#testing-and-verification).
+
+## Building distributable artifacts
+
+The project uses the [`uv`](https://docs.astral.sh/uv/) build backend. After installing `uv`
+(`pip install uv uv-build`), you can produce source and wheel distributions locally with:
+
+```bash
+uv build --wheel --sdist
+```
+
+Artifacts are written to the `dist/` directory. To test the wheel in a clean environment you can
+install it via `uv pip install dist/check_mate-<version>-py3-none-any.whl`. Publishing to an index
+is handled by `uv publish`, which reuses the same build backend and upload credentials.
 
 ## Python usage
 
@@ -35,11 +66,11 @@ print(cm.__version__)
 
 ## Useful Scripts
 
-This repository includes several scripts to help manage and monitor jobs. After installation, `check-hang`, `check-nan`, and `get-healthy-nodes` will be available in your PATH.
+This repository includes several scripts to help manage and monitor jobs. After installation, `check-mate-hang`, `check-mate-nan`, and `get-healthy-nodes` will be available in your PATH.
 
-- `check-hang`: Monitors files for updates and kills a job if it stops changing for longer than a specified timeout. This is useful for detecting hung processes.
+- `check-mate-hang`: Monitors files for updates and kills a job if it stops changing for longer than a specified timeout. This is useful for detecting hung processes.
   ```bash
-  check-hang --timeout 600 --check 10 --command "mpiexec python train.py"
+  check-mate-hang --timeout 600 --check 10 --command "mpiexec python train.py"
   ```
   **Arguments:**
   - `--timeout`: Seconds of inactivity after which the job will be killed (default: 300).
@@ -49,9 +80,9 @@ This repository includes several scripts to help manage and monitor jobs. After 
   - `--grace`: Seconds to wait after sending the kill command before exiting (default: 10).
   - `--dry-run`: If set, do not actually run the kill command—only log the action.
 
-- `check-nan`: Monitors text output files for `NaN` or `Inf` values and terminates the job if they are found. This is useful for catching numerical stability issues.
+- `check-mate-nan`: Monitors text output files for `NaN` or `Inf` values and terminates the job if they are found. This is useful for catching numerical stability issues.
   ```bash
-  check-nan --outputs "logs/*.out" --check 15 --kill-command "scancel $SLURM_JOB_ID"
+  check-mate-nan --outputs "logs/*.out" --check 15 --kill-command "scancel $SLURM_JOB_ID"
   ```
   **Arguments:**
   - `--outputs`: Glob pattern for files to watch.
@@ -100,11 +131,21 @@ python test_pyjob.py --fail 120 --checkpoint ./chkpt --niters 1000
 - [qsub_multi_mpiexec.sc](./qsub_multi_mpiexec.sc)
   submission script doing continual trials of mpiexec until success or timeout
 
-## Various simulation examples
-- [fail/](./fail): job failed after 100 seconds, restart
-- [hang/](./hang): job hang, kill and restart
-- [success/](./success): job run seccessfully
-- [nan/](./nan): NaN after a few iterations, restart
+## Packaged simulation examples
+Reusable PBS submission templates ship with the library and can be accessed as
+Python modules. Each example prints its `qsub.sc` template to `stdout` or writes
+it to disk when paired with `--output`:
+
+```bash
+# Preview the failing job template
+python -m check_mate.examples.fail
+
+# Persist the NaN recovery template to a custom location
+python -m check_mate.examples.nan --output ~/nan.sc
+```
+
+The available examples mirror the historical directories and cover failure,
+hang detection, NaN recovery, and successful completion scenarios.
 
 ## Checkpoint interval optimization utility
 - [optimal_checkpointing.py](./optimal_checkpointing.py)

--- a/docs/index.md
+++ b/docs/index.md
@@ -18,10 +18,31 @@ print(cm.__version__)
 
 ## Command-line tools
 
-- `check-hang` — watch checkpoint files for activity and terminate a job if they stall.
-- `check-nan` — inspect log files for `NaN`/`Inf` tokens and trigger recovery hooks.
+- `check-mate-hang` — watch checkpoint files for activity and terminate a job if they stall.
+- `check-mate-nan` — inspect log files for `NaN`/`Inf` tokens and trigger recovery hooks.
 - `get-healthy-nodes` — delegate to the bundled shell helper that prunes unresponsive nodes.
 - `check-mate-launcher` — export launcher-friendly environment variables and execute a command.
 - `check-mate-flush` — run the original flush helper used in PBS-style workflows.
 
 Refer to the [project README](https://github.com/argonne-lcf/checkpoint_restart#readme) for detailed usage examples.
+
+## Building and packaging
+
+`check-mate` is published using the [`uv` build backend](https://docs.astral.sh/uv/). After installing
+`uv` and `uv-build`, run `uv build --wheel --sdist` from the repository root to produce local
+artifacts. The resulting `dist/` directory mirrors what `uv publish` will upload to package indexes.
+
+## Packaged submission templates
+
+Sample PBS scripts are distributed with the library and can be previewed or saved locally via
+
+```bash
+python -m check_mate.examples.fail            # print the failing job template
+python -m check_mate.examples.hang --output hang.sc
+```
+
+## Testing and verification
+
+Refer to the [project README](https://github.com/argonne-lcf/checkpoint_restart#running-the-test-suite)
+for end-to-end setup instructions. The README covers creating an isolated environment, installing
+the optional `dev` extras (which pull in `pytest`), and running the regression suite locally.

--- a/examples/fail/test_pyjob.py
+++ b/examples/fail/test_pyjob.py
@@ -1,1 +1,0 @@
-../../test_pyjob.py

--- a/examples/hang/test_pyjob.py
+++ b/examples/hang/test_pyjob.py
@@ -1,1 +1,0 @@
-../../test_pyjob.py

--- a/examples/nan/test_pyjob.py
+++ b/examples/nan/test_pyjob.py
@@ -1,1 +1,0 @@
-../../test_pyjob.py

--- a/examples/success/test_pyjob.py
+++ b/examples/success/test_pyjob.py
@@ -1,1 +1,0 @@
-../../test_pyjob.py

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [build-system]
-requires = ["hatchling>=1.18"]
-build-backend = "hatchling.build"
+requires = ["uv_build>=0.9.1,<0.10.0"]
+build-backend = "uv_build"
 
 [project]
 name = "check-mate"
@@ -11,7 +11,7 @@ requires-python = ">=3.9"
 authors = [
   { name = "Huihuo Zheng", email = "huihuo.zheng@anl.gov" },
 ]
-license = { text = "MIT" }
+license = { file = "LICENSE" }
 keywords = ["hpc", "checkpoint", "monitoring", "exascale"]
 classifiers = [
   "Development Status :: 3 - Alpha",
@@ -35,9 +35,9 @@ Documentation = "https://example.com/check-mate"
 Source = "https://github.com/argonne-lcf/checkpoint_restart"
 
 [project.scripts]
-check-hang = "check_mate.check_hang:main"
-check-nan = "check_mate.check_nan:main"
 check-mate = "check_mate.cli:main"
+check-mate-hang = "check_mate.check_hang:main"
+check-mate-nan = "check_mate.check_nan:main"
 
 [project.optional-dependencies]
 docs = [
@@ -45,29 +45,9 @@ docs = [
   "mkdocs-material>=9.5",
 ]
 dev = [
+  "pytest>=7.4",
   "pre-commit>=3.6",
   "ruff>=0.4",
-]
-
-[tool.hatch.build]
-include = [
-  "src/check_mate",
-  "README.md",
-  "LICENSE",
-  "mkdocs.yml",
-  "docs",
-]
-
-[tool.hatch.build.targets.wheel]
-packages = ["src/check_mate"]
-force-include = { "src/check_mate/resources" = "check_mate/resources" }
-
-[tool.hatch.build.targets.sdist]
-include = [
-  "src/check_mate",
-  "README.md",
-  "mkdocs.yml",
-  "docs",
 ]
 
 [tool.ruff]

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,5 @@
+[pytest]
+testpaths = tests
+addopts = -ra
+pythonpath =
+    src

--- a/qsub_multi_mpiexec.sc
+++ b/qsub_multi_mpiexec.sc
@@ -28,10 +28,10 @@ do
     export PBS_NODEFILE=pbs_nodefile$RUN
 
     # constantly check the job and kill the job if it hangs for 300 seconds
-    check_hang.py --timeout 300 --outputs $PBS_JOBNAME.o$JOBID:$PBS_JOBNAME.e$JOBID:output.log --kill-command "pkill -u $USER mpiexec" >> check_hang.r$JOBID &
+    check-mate-hang --timeout 300 --outputs $PBS_JOBNAME.o$JOBID:$PBS_JOBNAME.e$JOBID:output.log --kill-command "pkill -u $USER mpiexec" >> check_hang.r$JOBID &
 
     # run the actual job, in this case, the job will run for 200 seconds and fail (finished about 9 iterations each time)
-    mpiexec -np $((JOBSIZE*12)) --ppn 12 launcher.sh python ./test_pyjob.py --compute 10 --niters 100 --output output.log 
+    mpiexec -np $((JOBSIZE*12)) --ppn 12 launcher.sh python -m check_mate.examples.test_pyjob --compute 10 --niters 100 --output output.log
 
     EXIT_CODE=$?
     # Check the job status
@@ -43,7 +43,7 @@ do
     fi
     echo "Rerun the job at `date`; time of trials: $RUN"
     # clear up the nodes for rerun the job
-    pkill check_hang.py
+    pkill check-mate-hang
     PBS_NODEFILE=nodefile_all flush.sh
     sleep 5
 done

--- a/src/check_mate/examples/__init__.py
+++ b/src/check_mate/examples/__init__.py
@@ -1,0 +1,78 @@
+"""Helper utilities for distributing checkpoint restart job examples."""
+from __future__ import annotations
+
+import argparse
+from importlib import resources
+from pathlib import Path
+from typing import Sequence
+
+__all__ = [
+    "available_examples",
+    "read_script",
+    "run_example_cli",
+]
+
+_SCRIPT_NAME = "qsub.sc"
+
+
+def available_examples() -> list[str]:
+    """Return the sorted collection of packaged example names."""
+    package_contents = resources.files(__name__)
+    examples: list[str] = []
+    for entry in package_contents.iterdir():
+        if entry.is_dir() and (entry / _SCRIPT_NAME).is_file():
+            examples.append(entry.name)
+    return sorted(examples)
+
+
+def _script_resource(example: str) -> resources.abc.Traversable:
+    script = resources.files(__name__).joinpath(example, _SCRIPT_NAME)
+    if not script.is_file():
+        raise FileNotFoundError(
+            f"No '{_SCRIPT_NAME}' script bundled for the '{example}' example."
+        )
+    return script
+
+
+def read_script(example: str) -> str:
+    """Return the contents of the packaged submission script for *example*."""
+    return _script_resource(example).read_text()
+
+
+def _write_script(example: str, destination: Path, overwrite: bool) -> Path:
+    destination.parent.mkdir(parents=True, exist_ok=True)
+    if destination.exists() and not overwrite:
+        raise FileExistsError(
+            f"Destination '{destination}' already exists. Use --overwrite to replace it."
+        )
+    destination.write_text(read_script(example))
+    return destination
+
+
+def run_example_cli(example: str, argv: Sequence[str] | None = None) -> int:
+    """Entry-point helper that prints or writes a packaged submission script."""
+    parser = argparse.ArgumentParser(
+        prog=f"check_mate.examples.{example}",
+        description=(
+            "Display the packaged batch submission script or write it to a file for easy reuse."
+        ),
+    )
+    parser.add_argument(
+        "--output",
+        type=Path,
+        help="Optional destination to write the script instead of printing it.",
+    )
+    parser.add_argument(
+        "--overwrite",
+        action="store_true",
+        help="Overwrite --output if it already exists.",
+    )
+    args = parser.parse_args(list(argv) if argv is not None else None)
+
+    if args.output is None:
+        print(read_script(example))
+        return 0
+
+    written_to = _write_script(example, args.output, args.overwrite)
+    print(f"Wrote {example} example submission script to {written_to}")
+    return 0

--- a/src/check_mate/examples/__main__.py
+++ b/src/check_mate/examples/__main__.py
@@ -1,0 +1,20 @@
+"""CLI entry point that enumerates the bundled examples."""
+from __future__ import annotations
+
+from . import available_examples
+
+
+def main() -> int:
+    examples = available_examples()
+    if not examples:
+        print("No packaged examples are available.")
+        return 0
+
+    print("Available Check Mate examples:\n")
+    for example in examples:
+        print(f"  python -m check_mate.examples.{example}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/check_mate/examples/fail/__init__.py
+++ b/src/check_mate/examples/fail/__init__.py
@@ -1,0 +1,15 @@
+"""Entry point helpers for the packaged example."""
+from __future__ import annotations
+
+from typing import Sequence
+
+from .. import run_example_cli
+
+EXAMPLE = __name__.rsplit('.', 1)[-1]
+
+__all__ = ["EXAMPLE", "main"]
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    """Dispatch to the shared example CLI helper."""
+    return run_example_cli(EXAMPLE, argv)

--- a/src/check_mate/examples/fail/__main__.py
+++ b/src/check_mate/examples/fail/__main__.py
@@ -1,0 +1,8 @@
+"""Module execution entry point for the packaged example."""
+from __future__ import annotations
+
+from . import main
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/check_mate/examples/fail/qsub.sc
+++ b/src/check_mate/examples/fail/qsub.sc
@@ -1,7 +1,7 @@
 #!/bin/bash
 #PBS -l walltime=0:20:00
 #PBS -q prod
-#PBS -N test_success
+#PBS -N test_fail
 #PBS -l select=4
 #PBS -A datascience
 #PBS -l filesystems=home:flare
@@ -29,10 +29,10 @@ do
     export PBS_NODEFILE=pbs_nodefile$RUN
 
     # constantly check the job and kill the job if it hangs for 300 seconds
-    check_hang.py --timeout 300 --outputs $PBS_JOBNAME.o$JOBID:$PBS_JOBNAME.e$JOBID:output.log --kill-command "pkill -u $USER python ./test_pyjob.py" >> check_hang.r$JOBID &
+    check-mate-hang --timeout 300 --outputs $PBS_JOBNAME.o$JOBID:$PBS_JOBNAME.e$JOBID:output.log --kill-command "pkill -u $USER mpiexec" >> check_hang.r$JOBID &
 
-    # run the actual job, in this case, the job will run for 200 seconds and fail (finished about 9 iterations each time)
-    mpiexec -np $((JOBSIZE*12)) --ppn 12 launcher.sh python ./test_pyjob.py --compute 10 --niters 100 --output output.log 
+    # run the actual job, in this case, the job will run for 20 seconds and fail (finished about 10 iterations each time)
+    mpiexec -np $((JOBSIZE*12)) --ppn 12 launcher.sh python -m check_mate.examples.test_pyjob --compute 2 --niters 100 --output output.log --fail 20
 
     EXIT_CODE=$?
     # Check the job status
@@ -44,7 +44,7 @@ do
     fi
     echo "Rerun the job at `date`; time of trials: $RUN"
     # clear up the nodes for rerun the job
-    pkill check_hang.py
+    pkill check-mate-hang
     PBS_NODEFILE=nodefile_all flush.sh
     sleep 5
 done

--- a/src/check_mate/examples/hang/__init__.py
+++ b/src/check_mate/examples/hang/__init__.py
@@ -1,0 +1,15 @@
+"""Entry point helpers for the packaged example."""
+from __future__ import annotations
+
+from typing import Sequence
+
+from .. import run_example_cli
+
+EXAMPLE = __name__.rsplit('.', 1)[-1]
+
+__all__ = ["EXAMPLE", "main"]
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    """Dispatch to the shared example CLI helper."""
+    return run_example_cli(EXAMPLE, argv)

--- a/src/check_mate/examples/hang/__main__.py
+++ b/src/check_mate/examples/hang/__main__.py
@@ -1,0 +1,8 @@
+"""Module execution entry point for the packaged example."""
+from __future__ import annotations
+
+from . import main
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/check_mate/examples/hang/qsub.sc
+++ b/src/check_mate/examples/hang/qsub.sc
@@ -29,14 +29,14 @@ do
     export PBS_NODEFILE=pbs_nodefile$RUN
 
     # constantly check the job and kill the job if it hangs for 300 seconds
-    check_hang.py --timeout 300 --outputs $PBS_JOBNAME.o$JOBID:$PBS_JOBNAME.e$JOBID:output.log --kill-command "pkill -u $USER mpiexe" >> check_hang.r$JOBID &
+    check-mate-hang --timeout 300 --outputs $PBS_JOBNAME.o$JOBID:$PBS_JOBNAME.e$JOBID:output.log --kill-command "pkill -u $USER mpiexe" >> check_hang.r$JOBID &
 
     # run the actual job, in this case, the job will run for 200 seconds and fail (finished about 9 iterations each time)
     if [[ $RUN -lt 2 ]]; then
 	# only hang for the first two times
-	mpiexec -np $((JOBSIZE*12)) --ppn 12 launcher.sh python ./test_pyjob.py --compute 2 --niters 100 --output output.log --hang 400
+        mpiexec -np $((JOBSIZE*12)) --ppn 12 launcher.sh python -m check_mate.examples.test_pyjob --compute 2 --niters 100 --output output.log --hang 400
     else
-	mpiexec -np $((JOBSIZE*12)) --ppn 12 launcher.sh python ./test_pyjob.py --compute 2 --niters 100 --output output.log
+        mpiexec -np $((JOBSIZE*12)) --ppn 12 launcher.sh python -m check_mate.examples.test_pyjob --compute 2 --niters 100 --output output.log
     fi
     EXIT_CODE=$?
     # Check the job status
@@ -48,7 +48,7 @@ do
     fi
     echo "Rerun the job at `date`; time of trials: $RUN"
     # clear up the nodes for rerun the job
-    pkill check_hang.py
+    pkill check-mate-hang
     PBS_NODEFILE=nodefile_all flush.sh
     sleep 5
 done

--- a/src/check_mate/examples/nan/__init__.py
+++ b/src/check_mate/examples/nan/__init__.py
@@ -1,0 +1,15 @@
+"""Entry point helpers for the packaged example."""
+from __future__ import annotations
+
+from typing import Sequence
+
+from .. import run_example_cli
+
+EXAMPLE = __name__.rsplit('.', 1)[-1]
+
+__all__ = ["EXAMPLE", "main"]
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    """Dispatch to the shared example CLI helper."""
+    return run_example_cli(EXAMPLE, argv)

--- a/src/check_mate/examples/nan/__main__.py
+++ b/src/check_mate/examples/nan/__main__.py
@@ -1,0 +1,8 @@
+"""Module execution entry point for the packaged example."""
+from __future__ import annotations
+
+from . import main
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/check_mate/examples/nan/qsub.sc
+++ b/src/check_mate/examples/nan/qsub.sc
@@ -29,10 +29,10 @@ do
     export PBS_NODEFILE=pbs_nodefile$RUN
 
     # constantly check the job and kill the job if it hangs for 300 seconds
-    check_hang.py --timeout 300 --outputs $PBS_JOBNAME.o$JOBID:$PBS_JOBNAME.e$JOBID:output.log --kill-command "pkill -u $USER mpiexec" >> check_hang.r$JOBID &
-    check_nan.py --check 1 --outputs $PBS_JOBNAME.o$JOBID:$PBS_JOBNAME.e$JOBID:output.log --kill-command "pkill -u $USER mpiexec" >> check_nan.r$JOBID &
+    check-mate-hang --timeout 300 --outputs $PBS_JOBNAME.o$JOBID:$PBS_JOBNAME.e$JOBID:output.log --kill-command "pkill -u $USER mpiexec" >> check_hang.r$JOBID &
+    check-mate-nan --check 1 --outputs $PBS_JOBNAME.o$JOBID:$PBS_JOBNAME.e$JOBID:output.log --kill-command "pkill -u $USER mpiexec" >> check_nan.r$JOBID &
     # run the actual job, in this case, the job will run for 200 seconds and fail (finished about 9 iterations each time)
-    mpiexec -np $((JOBSIZE*12)) --ppn 12 launcher.sh python ./test_pyjob.py --compute 5 --niters 100 --output output.log --nan-after 10
+    mpiexec -np $((JOBSIZE*12)) --ppn 12 launcher.sh python -m check_mate.examples.test_pyjob --compute 5 --niters 100 --output output.log --nan-after 10
 
     EXIT_CODE=$?
     # Check the job status

--- a/src/check_mate/examples/success/__init__.py
+++ b/src/check_mate/examples/success/__init__.py
@@ -1,0 +1,15 @@
+"""Entry point helpers for the packaged example."""
+from __future__ import annotations
+
+from typing import Sequence
+
+from .. import run_example_cli
+
+EXAMPLE = __name__.rsplit('.', 1)[-1]
+
+__all__ = ["EXAMPLE", "main"]
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    """Dispatch to the shared example CLI helper."""
+    return run_example_cli(EXAMPLE, argv)

--- a/src/check_mate/examples/success/__main__.py
+++ b/src/check_mate/examples/success/__main__.py
@@ -1,0 +1,8 @@
+"""Module execution entry point for the packaged example."""
+from __future__ import annotations
+
+from . import main
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/check_mate/examples/success/qsub.sc
+++ b/src/check_mate/examples/success/qsub.sc
@@ -1,7 +1,7 @@
 #!/bin/bash
 #PBS -l walltime=0:20:00
 #PBS -q prod
-#PBS -N test_fail
+#PBS -N test_success
 #PBS -l select=4
 #PBS -A datascience
 #PBS -l filesystems=home:flare
@@ -29,10 +29,10 @@ do
     export PBS_NODEFILE=pbs_nodefile$RUN
 
     # constantly check the job and kill the job if it hangs for 300 seconds
-    check_hang.py --timeout 300 --outputs $PBS_JOBNAME.o$JOBID:$PBS_JOBNAME.e$JOBID:output.log --kill-command "pkill -u $USER mpiexec" >> check_hang.r$JOBID &
+    check-mate-hang --timeout 300 --outputs $PBS_JOBNAME.o$JOBID:$PBS_JOBNAME.e$JOBID:output.log --kill-command "pkill -u $USER python -m check_mate.examples.test_pyjob" >> check_hang.r$JOBID &
 
-    # run the actual job, in this case, the job will run for 20 seconds and fail (finished about 10 iterations each time)
-    mpiexec -np $((JOBSIZE*12)) --ppn 12 launcher.sh python ./test_pyjob.py --compute 2 --niters 100 --output output.log --fail 20
+    # run the actual job, in this case, the job will run for 200 seconds and fail (finished about 9 iterations each time)
+    mpiexec -np $((JOBSIZE*12)) --ppn 12 launcher.sh python -m check_mate.examples.test_pyjob --compute 10 --niters 100 --output output.log
 
     EXIT_CODE=$?
     # Check the job status
@@ -44,7 +44,7 @@ do
     fi
     echo "Rerun the job at `date`; time of trials: $RUN"
     # clear up the nodes for rerun the job
-    pkill check_hang.py
+    pkill check-mate-hang
     PBS_NODEFILE=nodefile_all flush.sh
     sleep 5
 done

--- a/src/check_mate/examples/test_pyjob.py
+++ b/src/check_mate/examples/test_pyjob.py
@@ -1,0 +1,120 @@
+"""Synthetic workload used by the packaged submission templates."""
+
+from __future__ import annotations
+
+import argparse
+import datetime as _dt
+import os
+import threading
+import time
+from pathlib import Path
+from typing import Sequence
+
+__all__ = ["main", "build_parser"]
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Simulate long-running jobs with hangs, NaNs, and failures.",
+    )
+    parser.add_argument("--compute", default=10, type=int, help="Seconds per iteration")
+    parser.add_argument("--niters", default=100, type=int, help="Total number of iterations")
+    parser.add_argument("--checkpoint", default="latest", help="Checkpoint file path")
+    parser.add_argument("--hang", default=None, type=int, help="Optional hang duration in seconds")
+    parser.add_argument("--fail", default=None, type=int, help="Seconds before forced failure")
+    parser.add_argument("--exit-code", default=1, type=int, help="Exit code to use on failure")
+    parser.add_argument(
+        "--nan-after",
+        default=None,
+        type=int,
+        help="Iteration offset after which NaN/Inf values are emitted",
+    )
+    parser.add_argument(
+        "--save-interval",
+        default=1,
+        type=int,
+        help="Iterations between checkpoint writes",
+    )
+    parser.add_argument("--output", default="output.log", help="Destination log file")
+    parser.add_argument(
+        "--checkpoint_time", default=0, type=int, help="Seconds spent writing each checkpoint"
+    )
+    return parser
+
+
+def _spawn_fail_thread(delay: int, exit_code: int, rank: int) -> threading.Thread:
+    def trigger_failure() -> None:
+        if rank == 0:
+            print(f"WARNING: Job will run {delay} seconds and fail", flush=True)
+        time.sleep(delay)
+        os._exit(exit_code)
+
+    thread = threading.Thread(target=trigger_failure, name="failure-timer", daemon=True)
+    thread.start()
+    return thread
+
+
+def _read_checkpoint(path: Path, rank: int) -> int:
+    if path.is_file():
+        checkpoint = int(path.read_text().splitlines()[0])
+        if rank == 0:
+            print(f"Reading checkpoint from {checkpoint}")
+        return checkpoint
+
+    if rank == 0:
+        print("Starting job from scratch")
+    return 0
+
+
+def _write_checkpoint(path: Path, iteration: int) -> None:
+    path.write_text(f"{iteration}\n")
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = build_parser()
+    args = parser.parse_args(list(argv) if argv is not None else None)
+
+    rank = int(os.getenv("RANK", "0"))
+
+    failure_thread: threading.Thread | None = None
+    if args.fail and args.fail > 0:
+        failure_thread = _spawn_fail_thread(args.fail, args.exit_code, rank)
+
+    if rank == 0:
+        print(f"Job started at {_dt.datetime.now()}")
+
+    checkpoint_path = Path(args.checkpoint)
+    checkpoint = _read_checkpoint(checkpoint_path, rank)
+
+    if args.hang and args.hang > 0:
+        if rank == 0:
+            print(f"WARNING: job will hang for {args.hang} seconds")
+        time.sleep(args.hang)
+
+    with open(args.output, "w", encoding="utf-8") as fout:
+        for iteration in range(checkpoint, args.niters):
+            time.sleep(args.compute)
+            if (iteration - checkpoint + 1) % args.save_interval == 0:
+                time.sleep(args.checkpoint_time)
+                _write_checkpoint(checkpoint_path, iteration)
+
+            if rank == 0:
+                print(f"{iteration} iteration ...")
+                if args.nan_after is not None and (iteration - checkpoint) >= args.nan_after:
+                    fout.write(f"{iteration} iteration ..., result: NaN\n")
+                else:
+                    fout.write(f"{iteration} iteration ..., result: ...\n")
+                fout.flush()
+
+    if rank == 0:
+        print(f"Job finished at {_dt.datetime.now()}")
+
+    if failure_thread is not None:
+        failure_thread.join()
+        return args.exit_code
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/test_pyjob.py
+++ b/test_pyjob.py
@@ -1,69 +1,9 @@
 #!/usr/bin/env python
-import time
-import argparse
-import datetime
-import sys
-parser = argparse.ArgumentParser()
-parser.add_argument("--compute", default=10, type=int, help="time period for each iteration")
-parser.add_argument("--niters", default=100, type=int, help="number of iterations")
-parser.add_argument("--checkpoint", default="latest", type=str, help="checkpoint file")
-parser.add_argument("--hang", default=None, type=int, help="hang time in seconds")
-parser.add_argument("--fail", default=None, type=int, help="after how many seconds to fail")
-parser.add_argument("--exit-code", default=1, type=int, help="exit code when fail")
-parser.add_argument("--nan-after", default=None, type=int, help="after how many iterations to generate nan/inf")
-parser.add_argument("--save-interval", default=1, type=int, help="checkpoint saving interval")
-parser.add_argument("--output", default="output.log", type=str, help="output file")
-parser.add_argument("--checkpoint_time", default=0, type=int, help="time period for checkpointing")
-args = parser.parse_args()
-import os
-rank = int(os.getenv("RANK", "0"))
-import threading
+"""Backwards-compatibility shim for the packaged test job."""
+from __future__ import annotations
 
-def f(tt):
-    if rank==0:
-        print(f"WARNING: Job will run {tt} seconds and fail")
-    time.sleep(tt)
-    os._exit(args.exit_code)
-
-t1 = None
-if args.fail is not None:
-    t1 = threading.Thread(target=f, args=(args.fail,))    
-    t1.start()
+from check_mate.examples.test_pyjob import main
 
 
-if rank==0:
-    print(f"Job started at {datetime.datetime.now()}")
-
-if os.path.isfile(args.checkpoint):
-    checkpoint = int(open(args.checkpoint).readline())
-    if rank==0:
-        print(f"Reading checkpoint from {checkpoint}")
-else:
-    checkpoint=0
-    if rank==0:
-        print("Starting job from scratch")
-
-if (args.hang is not None) and args.hang > 0:
-    if rank==0:
-        print(f"WARNING: job will hang for {args.hang} seconds")
-    time.sleep(args.hang)
-fout = open(args.output, "w")    
-for i in range(checkpoint, args.niters):
-    time.sleep(args.compute)
-    if (i-checkpoint+1)%args.save_interval==0:
-        time.sleep(args.checkpoint_time)
-        with open(args.checkpoint, "w") as fc:
-            fc.write(f"{i}\n")
-    if rank==0:
-        print(f"{i} iteration ...")
-        if args.nan_after is not None and (i - checkpoint) >= args.nan_after:
-            fout.write(f"{i} iteration ..., result: NaN\n")
-            fout.flush()
-        else:
-            fout.write(f"{i} iteration ..., result: ...\n")
-fout.close()    
-if rank==0:
-    print(f"Job finished at {datetime.datetime.now()}")
-if args.fail is not None:
-    t1.join()
-    sys.exit(args.exit_code)
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_check_hang.py
+++ b/tests/test_check_hang.py
@@ -1,0 +1,68 @@
+import os
+import time
+
+import pytest
+
+from check_mate import check_hang
+
+
+def test_get_date_formats_timestamp():
+    timestamp = 1_700_000_000  # fixed epoch for reproducibility
+    formatted = check_hang.get_date(timestamp)
+    assert formatted == time.strftime("%Y-%m-%d %H:%M:%S", time.localtime(timestamp))
+
+
+def test_get_date_handles_none(monkeypatch):
+    sentinel = time.struct_time((2024, 1, 2, 3, 4, 5, 1, 2, -1))
+
+    def fake_localtime(value):
+        assert value is None
+        return sentinel
+
+    def fake_strftime(fmt, struct):
+        assert fmt == "%Y-%m-%d %H:%M:%S"
+        assert struct is sentinel
+        return "2024-01-02 03:04:05"
+
+    monkeypatch.setattr(check_hang, "localtime", fake_localtime)
+    monkeypatch.setattr(check_hang, "strftime", fake_strftime)
+
+    assert check_hang.get_date(None) == "2024-01-02 03:04:05"
+
+
+def test_get_date_rejects_invalid_timestamp():
+    with pytest.raises(TypeError):
+        check_hang.get_date("invalid")
+
+
+def test_most_recent_mtime_returns_latest(tmp_path):
+    file_a = tmp_path / "a.out"
+    file_b = tmp_path / "b.out"
+    file_a.write_text("a")
+    file_b.write_text("b")
+
+    # Ensure b has a newer timestamp
+    os.utime(file_b, None)
+
+    result = check_hang.most_recent_mtime([file_a, file_b])
+    assert result == file_b.stat().st_mtime
+
+
+def test_most_recent_mtime_ignores_missing(tmp_path):
+    missing = tmp_path / "missing.dat"
+    existing = tmp_path / "existing.dat"
+    existing.write_text("data")
+
+    result = check_hang.most_recent_mtime([missing, existing])
+    assert result == existing.stat().st_mtime
+
+
+def test_most_recent_mtime_returns_none_when_empty():
+    assert check_hang.most_recent_mtime([]) is None
+
+
+def test_most_recent_mtime_all_missing(tmp_path):
+    missing1 = tmp_path / "missing1.dat"
+    missing2 = tmp_path / "missing2.dat"
+    result = check_hang.most_recent_mtime([missing1, missing2])
+    assert result is None

--- a/tests/test_check_nan.py
+++ b/tests/test_check_nan.py
@@ -1,0 +1,195 @@
+import argparse
+import os
+import signal
+from types import SimpleNamespace
+
+import pytest
+
+from check_mate import check_nan
+
+
+def test_split_outputs_handles_mixed_delimiters():
+    specs = check_nan.split_outputs(" log1.txt:logs/*.out , result.log :: metrics.csv ")
+    assert specs == ["log1.txt", "logs/*.out", "result.log", "metrics.csv"]
+
+
+@pytest.mark.parametrize(
+    ("raw", "expected"),
+    [
+        ("", []),
+        (" :: , , ::", []),
+        ("alpha::beta, , gamma", ["alpha", "beta", "gamma"]),
+    ],
+)
+def test_split_outputs_handles_empty_and_malformed_segments(raw, expected):
+    assert check_nan.split_outputs(raw) == expected
+
+
+@pytest.mark.parametrize(
+    ("pattern", "expected"),
+    [
+        ("*.log", True),
+        ("logs/output.log", False),
+        ("file?.txt", True),
+        ("file1txt", False),
+        ("data[0-9].csv", True),
+        ("data9.csv", False),
+        ("**/*.log", True),
+        ("logs/logfile.log", False),
+        ("backup[!0-9]?.bak", True),
+        ("backupA1.bak", False),
+    ],
+)
+def test_is_glob_detects_special_characters(pattern, expected):
+    assert check_nan.is_glob(pattern) is expected
+
+
+def test_list_files_returns_existing_files(tmp_path):
+    file_a = tmp_path / "a.log"
+    file_a.write_text("hello")
+    nested = tmp_path / "nested"
+    nested.mkdir()
+    file_b = nested / "b.log"
+    file_b.write_text("world!")
+
+    specs = [str(file_a), str(tmp_path / "*.log"), str(nested / "*.log")]
+    files = check_nan.list_files(specs, recursive=False)
+
+    assert files[str(file_a)] == len("hello")
+    assert files[str(file_b)] == len("world!")
+
+
+def test_scan_new_bytes_tracks_offsets(tmp_path):
+    target = tmp_path / "log.txt"
+    target.write_text("12345")
+
+    end, chunk = check_nan.scan_new_bytes(str(target), 0)
+    assert end == 5
+    assert chunk == "12345"
+
+    target.write_text("12345abcdef")
+    end, chunk = check_nan.scan_new_bytes(str(target), end)
+    assert end == len("12345abcdef")
+    assert chunk == "abcdef"
+
+
+def test_scan_new_bytes_missing_file_is_safe(tmp_path):
+    start, chunk = check_nan.scan_new_bytes(str(tmp_path / "missing.log"), 10)
+    assert start == 10
+    assert chunk == ""
+
+
+@pytest.mark.parametrize(
+    ("text", "include_inf"),
+    [
+        ("loss=nan", False),
+        ("loss=INF", True),
+        ("loss=NaN", False),
+        ("loss=Inf", True),
+        ("error: nan", True),
+        ("error: (nan)", True),
+        ("error: inf", True),
+        ("error: [inf]", True),
+        ("error: nan,", True),
+        ("error: inf.", True),
+        ("error: nan;", True),
+        ("error: inf:", True),
+        ("error: nan!", True),
+        ("error: inf?", True),
+    ],
+)
+def test_contains_bad_tokens_detects_various_spellings(text, include_inf):
+    assert check_nan.contains_bad_tokens(text, include_inf)
+
+
+@pytest.mark.parametrize(
+    ("text", "include_inf"),
+    [
+        ("all good", True),
+        ("bananas are tasty", True),
+        ("infinite loop", True),
+        ("manifold learning", True),
+        ("information", True),
+        ("nanobot", True),
+        ("infinitesimal", True),
+    ],
+)
+def test_contains_bad_tokens_respects_token_boundaries(text, include_inf):
+    assert not check_nan.contains_bad_tokens(text, include_inf)
+
+
+@pytest.fixture()
+def fake_sleep(monkeypatch):
+    monkeypatch.setattr(check_nan.time, "sleep", lambda _: None)
+
+
+def test_try_kill_pid_and_command(monkeypatch, fake_sleep, capsys):
+    kills: list[tuple[int, int]] = []
+    commands: list[str] = []
+
+    def fake_kill(pid: int, sig: int) -> None:
+        kills.append((pid, sig))
+
+    def fake_run(cmd, shell, check):
+        assert shell and not check
+        commands.append(cmd)
+
+    monkeypatch.setattr(os, "kill", fake_kill)
+    monkeypatch.setattr(check_nan.subprocess, "run", fake_run)
+
+    args = argparse.Namespace(
+        dry_run=False,
+        pid=4242,
+        signal="TERM",
+        grace=1,
+        kill_command="echo kill",
+    )
+
+    check_nan.try_kill(args)
+
+    # After first invocation we expect TERM signal, a follow-up poll, escalation to
+    # SIGKILL, and the kill command execution.
+    assert kills == [
+        (4242, getattr(signal, "SIGTERM")),
+        (4242, 0),
+        (4242, signal.SIGKILL),
+    ]
+    assert commands == ["echo kill"]
+
+
+def test_try_kill_dry_run(capsys):
+    args = SimpleNamespace(
+        dry_run=True,
+        pid=0,
+        signal="TERM",
+        grace=0,
+        kill_command="",
+    )
+    check_nan.try_kill(args)
+    captured = capsys.readouterr()
+    assert "[DRY-RUN] Would terminate job" in captured.out
+
+
+def test_try_kill_invalid_signal():
+    args = SimpleNamespace(
+        dry_run=False,
+        pid=1234,
+        signal="NOT_A_SIGNAL",
+        grace=0,
+        kill_command="",
+    )
+    with pytest.raises(AttributeError):
+        check_nan.try_kill(args)
+
+
+def test_try_kill_warns_when_no_action(monkeypatch, capsys):
+    args = SimpleNamespace(
+        dry_run=False,
+        pid=0,
+        signal="TERM",
+        grace=0,
+        kill_command="",
+    )
+    check_nan.try_kill(args)
+    captured = capsys.readouterr()
+    assert "No kill action executed" in captured.out

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -1,0 +1,50 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from check_mate import examples
+
+EXPECTED_EXAMPLES = {"fail", "hang", "nan", "success"}
+
+
+def test_available_examples_includes_packaged_scripts():
+    available = set(examples.available_examples())
+    assert EXPECTED_EXAMPLES <= available
+
+
+def test_read_script_returns_script_contents():
+    script = examples.read_script("fail")
+    assert script.startswith("#!/bin/bash")
+    assert "check-mate-hang" in script
+    assert "python -m check_mate.examples.test_pyjob" in script
+
+
+def test_run_example_cli_prints_script(capsys):
+    exit_code = examples.run_example_cli("hang", [])
+    assert exit_code == 0
+    captured = capsys.readouterr()
+    assert "#!/bin/bash" in captured.out
+    assert captured.err == ""
+
+
+def test_run_example_cli_writes_output(tmp_path: Path, capsys):
+    destination = tmp_path / "example.sc"
+    exit_code = examples.run_example_cli("nan", ["--output", str(destination)])
+    assert exit_code == 0
+    assert destination.exists()
+    assert destination.read_text().startswith("#!/bin/bash")
+    captured = capsys.readouterr()
+    assert "Wrote nan example submission script" in captured.out
+
+
+def test_run_example_cli_requires_overwrite_flag(tmp_path: Path):
+    destination = tmp_path / "example.sc"
+    destination.write_text("placeholder")
+    with pytest.raises(FileExistsError):
+        examples.run_example_cli("success", ["--output", str(destination)])
+
+    exit_code = examples.run_example_cli("success", ["--output", str(destination), "--overwrite"])
+    assert exit_code == 0
+    assert destination.read_text().startswith("#!/bin/bash")

--- a/tests/test_optimal_checkpointing.py
+++ b/tests/test_optimal_checkpointing.py
@@ -1,0 +1,124 @@
+import math
+
+import pytest
+
+from check_mate.optimal_checkpointing import compute_efficiency, optimal_checkpoint_cadence
+
+
+def solve_expected_cadence(
+    node_count: int,
+    node_memory: float,
+    *,
+    MTBAI: float = 0.67,
+    chkpt_bandwidth: float = 5000.0,
+    R_0: float | None = None,
+) -> float:
+    """Re-implement the scalar root solve using a pure-Python bisection check."""
+    if R_0 is None:
+        R_0 = 1 / (MTBAI * 10624)
+
+    tau_c = (node_memory / chkpt_bandwidth) / 3600
+    u_chk = tau_c * node_count**2
+    z_chk = R_0 * u_chk
+
+    def f(z_c: float) -> float:
+        return math.exp(-z_c - z_chk) - (1 - z_c)
+
+    lo, hi = 0.0, max(1.5 * z_chk, 1.0)
+    f_lo = f(lo)
+    f_hi = f(hi)
+    assert f_lo * f_hi <= 0, "Bracket must contain the root"
+
+    for _ in range(200):
+        mid = 0.5 * (lo + hi)
+        f_mid = f(mid)
+        if abs(f_mid) <= 1e-12 or hi - lo <= 1e-12:
+            z_c = mid
+            break
+        if f_mid * f_lo > 0:
+            lo, f_lo = mid, f_mid
+        else:
+            hi, f_hi = mid, f_mid
+    else:  # pragma: no cover - defensive guard
+        raise RuntimeError("Bisection did not converge")
+
+    u_c = z_c / R_0
+    return u_c / node_count
+
+
+def test_optimal_checkpoint_cadence_matches_reference_bandwidth_default():
+    cadence = optimal_checkpoint_cadence(node_count=64, node_memory=32)
+    expected = solve_expected_cadence(node_count=64, node_memory=32)
+    assert cadence == pytest.approx(expected, rel=1e-6)
+
+
+def test_optimal_checkpoint_cadence_respects_named_bandwidth():
+    cadence = optimal_checkpoint_cadence(
+        node_count=64,
+        node_memory=32,
+        chkpt_bandwidth="LUSTRE",
+    )
+    expected = solve_expected_cadence(
+        node_count=64,
+        node_memory=32,
+        chkpt_bandwidth=650.0,
+    )
+    assert cadence == pytest.approx(expected, rel=1e-6)
+
+
+def test_optimal_checkpoint_cadence_with_extremely_large_bandwidth():
+    baseline = optimal_checkpoint_cadence(node_count=64, node_memory=32)
+    huge_bandwidth = optimal_checkpoint_cadence(
+        node_count=64,
+        node_memory=32,
+        chkpt_bandwidth=1e12,
+    )
+    assert huge_bandwidth < baseline
+
+
+def test_optimal_checkpoint_cadence_with_extremely_small_bandwidth():
+    baseline = optimal_checkpoint_cadence(node_count=64, node_memory=32)
+    tiny_bandwidth = optimal_checkpoint_cadence(
+        node_count=64,
+        node_memory=32,
+        chkpt_bandwidth=1e-6,
+    )
+    assert tiny_bandwidth > baseline
+
+
+@pytest.mark.parametrize(
+    "field,kwargs",
+    [
+        ("node_count", {"node_count": 0, "node_memory": 32}),
+        ("node_memory", {"node_count": 64, "node_memory": 0}),
+        ("chkpt_bandwidth", {"node_count": 64, "node_memory": 32, "chkpt_bandwidth": 0}),
+    ],
+)
+def test_optimal_checkpoint_cadence_rejects_non_positive_parameters(field, kwargs):
+    with pytest.raises(ValueError) as excinfo:
+        optimal_checkpoint_cadence(**kwargs)
+    assert field in str(excinfo.value)
+
+
+@pytest.mark.parametrize("bandwidth", ["UNKNOWN", None])
+def test_optimal_checkpoint_cadence_rejects_invalid_bandwidth_inputs(bandwidth):
+    with pytest.raises(TypeError):
+        optimal_checkpoint_cadence(node_count=8, node_memory=8, chkpt_bandwidth=bandwidth)
+
+
+def test_compute_efficiency_matches_manual_result():
+    cadence = optimal_checkpoint_cadence(node_count=64, node_memory=32)
+    efficiency = compute_efficiency(node_count=64, node_memory=32)
+    expected_eff = math.exp(-(4.0 + 3.0) / cadence)
+    assert efficiency == pytest.approx(expected_eff, rel=1e-6)
+
+
+def test_compute_efficiency_warns_for_tiny_cadence():
+    with pytest.warns(UserWarning):
+        compute_efficiency(node_count=4096, node_memory=8)
+
+
+@pytest.mark.parametrize("node_memory", [0, -8])
+def test_compute_efficiency_rejects_non_positive_memory(node_memory):
+    with pytest.raises(ValueError):
+        compute_efficiency(node_count=64, node_memory=node_memory)


### PR DESCRIPTION
## Summary
- rename the public CLI entry points to the check-mate-* convention and update the bundled example scripts to match the new command names, including the multi-job PBS template
- switch packaging to the uv build backend, document uv build/publish workflows, and expose the synthetic test workload as an importable module for python -m execution
- refresh tests and pre-commit configuration so ruff formatting runs automatically

## Testing
- pytest
- ruff check tests/test_examples.py src/check_mate/examples/test_pyjob.py

------
https://chatgpt.com/codex/tasks/task_e_68e7f0164ba8832aa4bec9e3d976197f